### PR TITLE
added option to remove blocks associated with water

### DIFF
--- a/pybna/importer.py
+++ b/pybna/importer.py
@@ -133,7 +133,8 @@ class Importer(Conf):
 
 
     def import_census_blocks(self,fips=None,url=None,fpath=None,table=None,
-                             keep_case=False,columns=None,id=None,geom=None,
+                             keep_case=False,keep_water=False,
+                             columns=None,id=None,geom=None,
                              srid=None,boundary_file=None,overwrite=False):
         """
         Retrieves census block features and saves them to the
@@ -154,6 +155,8 @@ class Importer(Conf):
             the table name to save blocks to (if none use config) (must be schema-qualified)
         keep_case : bool, optional
             whether to prevent column names from being converted to lower case
+        keep_water : bool, optional
+            whether to omit census blocks that are associated with water only areas
         columns : list, optional
             list of columns in the dataset to keep (if none keeps all)
         id : str, optional
@@ -234,6 +237,11 @@ class Importer(Conf):
         # filter to blocks within the boundary
         print("Filtering blocks to boundary")
         blocks = blocks[blocks.intersects(boundary.unary_union)]
+
+        # filter out blocks associated with water
+        if keep_water is False:
+            print("Filtering out water")
+            blocks = blocks[blocks.blockce.str[0] != '0']
 
         # copy data to db
         print("Copying blocks to database")


### PR DESCRIPTION
Add boolean 'keep_water' argument to import_census_blocks() that omits blocks associated with water. This method leverages the census block id structure, which is quick and simple. Blocks that begin with 0 are considered to be associated with water according to the US census. 

From 2010 Census Summary, Appendix A, Blocks: "Census Block Numbers—Census blocks are numbered uniquely with a four-digit census block number from 0000 to 9999 within census tract, which nest within state and county. The first digit of the census block number identifies the block group. Block numbers beginning with a zero (in Block Group 0) are only associated with water-only areas."

https://www.census.gov/prod/cen2010/doc/sf1.pdf#page=605&zoom=100,0,0 

Noting this method was tested, but I had issues with gtf_to_postgis(). I'm guessing this relates to version control (doesn't seem to be related to the boundary file I mentioned earlier today). 
