### PR TITLE
omitted most crosswalks

### DIFF
--- a/pybna/sql/importer/roads/50_insert.sql
+++ b/pybna/sql/importer/roads/50_insert.sql
@@ -43,6 +43,11 @@ CREATE TEMP TABLE tmp_combined AS (
         LEFT JOIN tmp_park_tf
             ON osm.id = tmp_park_tf.id
     WHERE COALESCE(osm."bicycle",'') != 'no'
+    AND   (SELECT CASE
+            WHEN (osm.highway = 'footway' AND osm.footway = 'crossing')
+            THEN (osm."bicycle" = 'yes')
+            ELSE TRUE
+            END)
 );
 
 INSERT INTO {roads_schema}.{roads_table}

--- a/pybna/sql/importer/roads/50_insert.sql
+++ b/pybna/sql/importer/roads/50_insert.sql
@@ -42,12 +42,13 @@ CREATE TEMP TABLE tmp_combined AS (
             ON osm.id = tmp_park_ft.id
         LEFT JOIN tmp_park_tf
             ON osm.id = tmp_park_tf.id
-    WHERE COALESCE(osm."bicycle",'') != 'no'
-    AND   (SELECT CASE
-            WHEN (osm.highway = 'footway' AND osm.footway = 'crossing')
-            THEN (osm."bicycle" = 'yes')
-            ELSE TRUE
-            END)
+    WHERE
+        COALESCE(osm."bicycle",'') != 'no'
+        AND CASE
+                WHEN (osm.highway = 'footway' AND osm.footway = 'crossing')
+                    THEN (osm."bicycle" IN ('yes','designated'))
+                ELSE TRUE
+                END
 );
 
 INSERT INTO {roads_schema}.{roads_table}

--- a/pybna/sql/importer/roads/50_insert.sql
+++ b/pybna/sql/importer/roads/50_insert.sql
@@ -43,10 +43,13 @@ CREATE TEMP TABLE tmp_combined AS (
         LEFT JOIN tmp_park_tf
             ON osm.id = tmp_park_tf.id
     WHERE
-        COALESCE(osm."bicycle",'') != 'no'
+        COALESCE(osm."bicycle",'') NOT LIKE '%no%'
         AND CASE
-                WHEN (osm.highway = 'footway' AND osm.footway = 'crossing')
-                    THEN (osm."bicycle" IN ('yes','designated'))
+                WHEN (osm.highway LIKE '%footway%' AND osm.footway LIKE '%crossing%')
+                    THEN (
+                        COALESCE(osm."bicycle",'') LIKE '%yes%'
+                        OR COALESCE(osm."bicycle",'') LIKE '%designated%'
+                    )
                 ELSE TRUE
                 END
 );


### PR DESCRIPTION
Here's pull request to omit most crosswalks. Please see the review table: received.updated_ways_no_ped_crosswalks. 

To handle this, I first read the [wiki page on crosswalks](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcrossing) and did some exploration in overpass-turbo and found that crosswalks can be selected with, highway=footway and footway=crossing – [here’re the results](https://overpass-turbo.eu/s/T13). 

To make sure to include crosswalks where bikes are permitted, I found the additional parameter, [bicycle = yes can be used to locate these segments](https://overpass-turbo.eu/s/T18). 

With the information described about, I built an addition to the WHERE clause in 50_insert.sql script that builds the final network.

I made sure this did not omit cycleway crossings [by using this query to located them](https://overpass-turbo.eu/s/T17), and comparing agaist the outputs from this change. 

Let me know if any of this is not clear.  
