### PR TITLE
open with implicit close

### DIFF
--- a/pybna/importer.py
+++ b/pybna/importer.py
@@ -55,7 +55,8 @@ class Importer(Conf):
         self.module_dir = os.path.dirname(os.path.abspath(__file__))
         if config is None:
             config = os.path.join(self.module_dir,"config.yaml")
-        self.config = self.parse_config(yaml.safe_load(open(config)))
+        with open(config) as config_yaml:
+            self.config = self.parse_config(yaml.safe_load(config_yaml))
         print("Connecting to database")
         if host is None:
             host = self.config.db.host

--- a/pybna/pybna.py
+++ b/pybna/pybna.py
@@ -60,7 +60,9 @@ class pyBNA(Conf,Destinations,Connectivity,Core):
         self.module_dir = os.path.dirname(os.path.abspath(__file__))
         if config is None:
             config = os.path.join(self.module_dir,"config.yaml")
-        self.config = self.parse_config(yaml.safe_load(open(config)))
+
+        with open(config) as f:
+            self.config = self.parse_config(yaml.safe_load(f))
         self.config["bna"]["connectivity"]["max_detour"] = float(100 + self.config["bna"]["connectivity"]["max_detour"])/100
         self.db_connectivity_table = self.config["bna"]["connectivity"]["table"]
         self.net_config = self.config["bna"]["network"]


### PR DESCRIPTION
I was curious about the resource warning when i ran pybna.importer. 

After a brief stack overflow roasting the only options for closing the file once it's read are to assign a variable to the object created by `open()` and use `f.close()` or use `with` so i threw that together in case you want it. 