### PR TITLE
overpass query syntax

### DIFF
--- a/pybna/importer.py
+++ b/pybna/importer.py
@@ -934,8 +934,8 @@ class Importer(Conf):
         geojson of ways, geojson of nodes
         """
         query_root = ["({},{},{},{}){}".format(min_lat,min_lon,max_lat,max_lon,tag) for tag in tags]
-        way_query = "way" + ";way".join(query_root) + ";"
-        node_query = "node" + ";node".join(query_root) + ";"
+        way_query = "(way" + ";way".join(query_root) + ";);"
+        node_query = "(node" + ";node".join(query_root) + ";);"
 
         api = overpass.API(timeout=600)
         ways = api.get(way_query,verbosity="geom")


### PR DESCRIPTION
This is a pretty simple fix. I just needed to wrap the overpass query in `(...)` to ensure that the results being pulled area a union of the individual queries and not just the last query - details [here](https://wiki.openstreetmap.org/wiki/Overpass_API/Language_Guide#The_union_operator:_combining_results_and_forming_sets)
 I tested the imports and saved the code [here](https://github.com/tooledesign/pybna_testing/tree/destination_overpass_imports/08_destinations_overpass_import)

The imports seems to be working as intended on overpass. I did note that there is a slight discrepancy in the number of destinations being imported between importing from a PBF file and overpass directly. It does not seem to be limited to multiple queries. In general, the overpass import rows seem to be slightly less in number than overpass imports. The number is pretty small and may not affect BNA results much, but something to look into for later. I suspect it has something to do with PBF potentially having historic locations as well as current ones. This is only a guess based on spot checking and will need to be explored more to be certain. I'll open a different issue for this.
