### PR TITLE
truncate by edge

### DIFF
--- a/pybna/importer.py
+++ b/pybna/importer.py
@@ -697,7 +697,7 @@ class Importer(Conf):
         else:
             G = ox.graph_from_polygon(
                 boundary,network_type='all',simplify=True,retain_all=True,
-                truncate_by_edge=False,clean_periphery=True,
+                truncate_by_edge=True,
                 custom_filter=None
             )
         G = ox.get_undirected(G)


### PR DESCRIPTION
The `truncate_by_edge` argument was set to `False` before which means any osm network imports will only contain a segment if both nodes of the of the link are within the study area. I think we should include segments even if one node of the segment is outside the study area as long as one node is inside. For large buffers, the impact of this is pretty minimal. But if the study area and the buffer is not large, those segments missed are a bit more obvious. Including those segments will not really have a negative impact on the analysis.

I also removed the `clean_periphery` argument which is [deprecated in osmnx](https://osmnx.readthedocs.io/en/stable/user-reference.html#osmnx.graph.graph_from_polygon).